### PR TITLE
feat: Add optional arm64 support for Docker images

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,9 +26,12 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
       - name: Build and push image
-        uses: docker/build-push-action@v1
+        uses: docker/build-push-action@v4
         with:
+          platforms: linux/amd64,linux/arm64
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
           repository: littleangryclouds/alertmanager-actions

--- a/README.md
+++ b/README.md
@@ -59,6 +59,15 @@ It's possible to read a more complete step by step documentation
 Also, there's a docker image you may use in [Docker
 Hub](https://hub.docker.com/repository/docker/littleangryclouds/alertmanager-actions).
 
+## Docker Image
+
+The Docker images are available for both `amd64` and `arm64` architectures.
+You can pull the `arm64` image using the following command:
+
+```bash
+docker pull littleangryclouds/alertmanager-actions --platform linux/arm64
+```
+
 ## Metrics
 It exposes some prometheus metrics. The ones that come with
 [Pyms](https://py-ms.readthedocs.io/en/latest/services/#metrics)


### PR DESCRIPTION
This commit introduces optional arm64 support for the Docker images.

Key changes:
- Modified `.github/workflows/main.yml`:
    - Upgraded `docker/build-push-action` to `v4`.
    - Added `docker/setup-qemu-action@v3` to enable multi-arch builds.
    - Configured the build-push action to build for `linux/amd64` and `linux/arm64` platforms.
- Updated `README.md`:
    - Added a section detailing the availability of multi-architecture Docker images.
    - Included an example command for pulling `arm64` specific images.

The Dockerfile itself did not require changes as the existing build dependencies (`gcc`, `python3-dev`) are expected to be sufficient for compiling dependencies like `uwsgi` on an `arm64` architecture when using QEMU for emulation during the GitHub Actions build. The actual validation of the arm64 build will occur in the CI pipeline when the workflow is triggered.